### PR TITLE
removing trimpath flag to enable Cloud Code debugging capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ ENV GOTRACEBACK=all
 ARG SKAFFOLD_GO_GCFLAGS
 # Copy in source files
 COPY *.go *.html ./
-RUN go build -trimpath -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o app
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o app
 CMD ["/go/src/app/app"]
 COPY k8s k8s


### PR DESCRIPTION
It appears Cloud Code Debug needs the paths included in the compile to properly map back to the source code entries. Removing -trimpath from the go build command to leave the file paths intact. 